### PR TITLE
Updating Swedish translation

### DIFF
--- a/sv.ini
+++ b/sv.ini
@@ -7,51 +7,51 @@
 display_name = Svenska
 
 [advanced_mode]
-description = Du kommer att träda in i "Avancerat Läge".
+description = Du kommer att träda in i "Avancerat läge".
 title = Varning - Viktigt
 
 [ani_controls]
 shortcut = Kortkommando:
-right_click = Höger-klick: Visa uppspelningsalternativ
+right_click = Högerklick: Visa uppspelningsalternativ
 
 [anidir_combo]
 forward = Frammåt
 reverse = Bakåt
 ping_pong = Pingis
-ping_pong_reverse = Ping-pong Bakvänd
+ping_pong_reverse = Pingis, bakvänd
 
 [ask_for_color_profile]
 title = Färgprofil
 sprite_with_profile = Bilden innehåller en färgprofil.
-sprite_without_profile = Bilden innehåller inte en färgprofil.
+sprite_without_profile = Bilden innehåller ingen färgprofil.
 
 [statusbar_tips]
 all_layers_are_locked = Alla valda lager är låsta
 layer_locked = Lager "{0}" är låst
 frame = Ruta:
-current_frame = Aktuell Ruta
-new_frame = Ny Ruta
+current_frame = Aktuell ruta
+new_frame = Ny ruta
 locked_layers = Det finns låsta lager
 no_active_layers = Det finns inget aktivt lager
-layer_x_is_hidden = Lager "{}" är gömt
+layer_x_is_hidden = Lager "{}" är dolt
 unmodifiable_reference_layer = Lager "{}" är en referens, kan ej modifieras
 filter_no_unlocked_layer = Inga upplåsta lager för att applicera filter
 cannot_move_bg_layer = Bakgrundslagret kan ej flyttas
 nothing_to_move = Inget att flytta
-zoom_level = Zoom-nivå
+zoom_level = Zoomnivå
 recovery_task_using_sprite = Bilden används inom en backup/dataåterställningsuppgift
-disable_snap_grid = Inaktivera Fäst till Rutnät
-non_transformable_reference_layer = Lager "{}" är en reference, kan inte transformeras
+disable_snap_grid = Inaktivera Fäst till rutnät
+non_transformable_reference_layer = Lager "{}" är en referens, kan inte transformeras
 sprite_locked_somewhere = Sprite är låst i annan redaktör
-not_enough_transform_memory = Ej tillräckligt minne för att transformera urval
-not_enough_rotsprite_memory = Ej tillräckligt minne för RotSprite
-cannot_modify_readonly_sprite = Kan ej modifiera en skrivskyddad sprite.\nAnvänd "Fil > Save" meny för mer information.
+not_enough_transform_memory = Inte tillräckligt minne för att transformera urval
+not_enough_rotsprite_memory = Inte tillräckligt minne för RotSprite
+cannot_modify_readonly_sprite = Kan ej modifiera en skrivskyddad sprite.\nAnvänd "Arkiv > Spara" meny för mer information.
 
 [alerts]
-applying_filter = FX<<Verkställer effekt...||&Avbryt
+applying_filter = FX<<Verkställer effekt ...||&Avbryt
 cannot_delete_all_layers = Fel<<Du kan inte ta bort alla lager.||&OK
-delete_selected_backups = Varning\n<<Vill du verkligen radera de utvalda {0} backup(s)?\n||&Ja||&Nej
-delete_shortcut = Varning\n<<Vill du verkligen radera "{0}" tangent genvägar?\n||&Ja||&Nej
+delete_selected_backups = Varning\n<<Vill du verkligen radera de {0} utvalda säkerhetskopiorna?\n||&Ja||&Nej
+delete_shortcut = Varning\n<<Vill du verkligen radera kortkommandot "{0}"?\n||&Ja||&Nej
 empty_rect_importing_sprite_sheet = Importera Sprite Sheet\n<<Den speciferade rektangeln skapar inga rutor.\n<<Välj en rektangel inom Sprite-regionen.\n||&OK
 error_loading_file = Fel<<Fel vid laddning av fil: {0}||&OK
 error_saving_file = Fel<<Fel vid sparning av fil: {0}||&OK
@@ -59,14 +59,14 @@ file_format_doesnt_support_palette = Fel<<Kan inte spara en färgpalett i {0} fo
 export_animation_in_sequence = Notis\n<<Vill du exportera animationen i {0} filer?\n<<{1}, {2}...\n||&Acceptera||&Avbryt
 deleting_tilemaps_will_delete_tilesets = Varning!\n<<Radering av de följande tilemaps kommer radera deras tilesets:\n<<"{0}"\n<<Vill du fortsätta ändå?\n||&OK||Avbryt
 auto_remap = Automatisk Tangentkartläggning\n<<Kartläggningen kan inte genomföras perfekt med mer än 256 färger.\n<<Vill du fortsätta ändå?\n||&OK||&Avbryt
-cannot_delete_used_tileset = Error\n<<Kan ej radera tileset använd av de följande tilemaps:\n<<"{0}"\n||&OK
+cannot_delete_used_tileset = Fel\n<<Kan ej radera tileset använd av de följande tilemaps:\n<<"{0}"\n||&OK
 cannot_file_overwrite_on_export = Varning för överskrivning\n<<Du kan inte Exportera med samma namn (skriv över orginalfilen.\n<<Använd "Fil > Spara Som" menyalternativet i så fall".\n||&OK
-cannot_open_file = Problem <<Kan inte öppna filen:<<{0}||&OK
-cannot_save_in_read_only_file = Problem : Den valda filen är skrivskyddad. Försök med annan fil.||& Gå tillbaka
+cannot_open_file = Fel <<Kan inte öppna filen:<<{0}||&OK
+cannot_save_in_read_only_file = Fel: Den valda filen är skrivskyddad. Försök med annan fil.||& Gå tillbaka
 clipboard_access_locked = Fel <<Kan inte komma åt klippbordet. << Kanske annan applikation använder den. ||&OK
 clipboard_image_format_not_supported = Fel: Bildformatet av det aktuella bildurklippet stöds inte.. ||&OK
 file_format_doesnt_support_error = Fel\n<<Fil format ".{0}" stödjes ej:\n<<\n{1}\n<<\n<<Du måste välja annat format. \n<<Använd ".aseprite" för att hålla all spriteinformation. \n || & OK
-file_format_alpha_channel = Alpha kanal
+file_format_alpha_channel = Alfakanal
 file_format_tags = Taggar
 file_format_frames = Bildrutor
 file_format_grayscale_mode = Gråskaleläge
@@ -74,21 +74,21 @@ file_format_indexed_mode = Indexerat läge
 file_format_layers = Lager
 file_format_palette_changes = Palett växlar mellan bildrutor
 file_format_rgb_mode = RGB-läge
-file_format_20ms_min_duration = Bildrute-längd är mindre än 20ms
-file_format_10ms_duration_precision = Bildrute-längd annan än en multipel på 10 ms
+file_format_20ms_min_duration = Bildrutelängd är mindre än 20 ms
+file_format_10ms_duration_precision = Bildrutelängd annan än en multipel på 10 ms
 invalid_chars_in_filename = Fel\n<<Filnamn kan ej innehålla de följande karaktärer:\n<< {0}\n||&OK
-cannot_open_folder = Problem <<Kan inte öppna mappen:<<{0}||&OK
+cannot_open_folder = Fel <<Kan inte öppna mappen:<<{0}||&OK
 file_format_doesnt_support_warning = Varning\n<<Fil format ".{0}" stödjes ej:\n<<\n{1}\n<<\n<<Du kan använda ".aseprite" formatet för att spara all denna information.\n<<Vill du fortsätta med ".{0}" ändå?\n||&Ja||&Nej
 invalid_fg_or_bg_colors = Aseprite\n<<Den aktuellt valda förgrundsfärg och/eller bakgrundsfärg\n<<är utom räckvidd. Välj en giltig färg i paletten.\n||&OK
 enter_license_disabled = Information\n<<Denna kopia av Aseprite stöder inte att ange en licensnyckel.\n<<Överväga skaffa en från https://aseprite.org/download.\n<<Aktivering av Aseprite ger åtkomst till automatiska uppdateringar.\n||&OK
 overwrite_files_on_export = Exportvarning\n<<Vill du skriva över följande fil?\n<<{0}\n||&Ja||&Nej
-job_working = {0}<<Arbetar...||&Cancel
+job_working = {0}<<Arbetar ...||&Cancel
 nothing_to_report = Krashrapport<<Inget att rapportera||&OK
-uninstall_extension_warning = Varning\n<<Vill du verkligen avinstallera "{0}" tillägg?\n||&Ja||&Nej
+uninstall_extension_warning = Varning\n<<Vill du verkligen avinstallera tillägget "{0}"?\n||&Ja||&Nej
 unknown_output_file_format_error = Aseprite\n<<Okänt filformat "{0}" i output filnamn\n||&OK
 update_extension_downgrade = nedgradera
 update_extension_upgrade = uppgradera
-recent_file_doesnt_exist = Aseprite<<Den valda filen existerar inte||&OK
+recent_file_doesnt_exist = Aseprite<<Den valda filen finns inte||&OK
 restart_by_preferences = Aseprite\n<<Du måste starta om programmet för att se dina ändringar till:{0}\n||&OK
 restart_by_preferences_keep_closed_sprite_on_memory_for = Håll stängd sprite i minne i X minuter
 install_extension = Varning\n<<Vill du verkligen installera det valda tillägget?\n<<"{0}"\n||&Installera||&Avbryt
@@ -106,7 +106,7 @@ save_sprite_changes = Varning\n<<Sparar ändringar till din sprite\n<<"{0}" inna
 overwrite_files_on_export_sprite_sheet = Exportvarning av Spriteark\n<<Vill du ersätta följande fil(er)?\n{0}\n||&Ja||&Nej
 
 [brightness_contrast]
-title = Ljusstyrka/Kontrast
+title = Ljusstyrka/kontrast
 brightness_label = Ljusstyrka:
 contrast_label = Kontrast:
 
@@ -121,11 +121,11 @@ ink_type = Typ
 ink_opacity = Opacitet
 extras = Extra:
 shade = Nyans
-pixel_perfect = Pixel-Perfekt
-save_brush = Spara Pensel Här
+pixel_perfect = Pixelperfekt
+save_brush = Spara pensel här
 locked = Låst
 delete = Radera
-delete_all = Radera Allt
+delete_all = Radera allt
 title = Parametrar
 brush = Pensel:
 brush_type = Typ
@@ -145,10 +145,10 @@ link_cels = &Länka Celler
 fg = Förgrundsfärg
 fg_warning = Lägg till förgrundsfärg till paletten
 edit_color = Redigera färg
-sort_and_gradients = Sortera & Gradienter
+sort_and_gradients = Sortera & övertoning
 presets = Förinställningar
 options = Alternativ
-switch_tileset = Visa Tileset / Högerklicka för att Bara Visa Tileset
+switch_tileset = Visa tileset / Högerklicka för att bara visa tileset
 tileset_mode_manual = Handbok: Ändra existerande plattor, skapa inte nya plattor automatiskt
 tileset_mode_stack = Stapla: Modifiera inte existerande plattor,\ngenerera och stapla nya plattor automatiskt
 set_as_default = Ställ in som standard
@@ -170,7 +170,7 @@ bottom = Botten:
 
 [export_file]
 cancel = &Avbryt
-title = Exportera Fil
+title = Exportera fil
 export = &Exportera
 
 [cel_properties]
@@ -213,8 +213,8 @@ section_menus = Menyer
 section_commands = Kommandon
 section_mouse_wheel = Mushjul
 ok = &OK
-import_keyboard_sc = Importera Kortkommandon
-export_keyboard_sc = Exportera Kortkommandon
+import_keyboard_sc = Importera kortkommandon
+export_keyboard_sc = Exportera kortkommandon
 section_tools = Verktyg
 cancel = &Avbrytt
 
@@ -229,10 +229,10 @@ file_open = &Öppna...
 file_save = &Spara
 file_import = &Importera
 file_export_as = &Exportera som...
-file_exit = A&vslut
+file_exit = &Avsluta
 edit = &Redigera
-file = &Fil
-file_save_as = Spara &som...
+file = &Akriv
+file_save_as = Spara so&m...
 file_close = &Stäng
 file_close_all = Stäng alla
 file_export = &Exportera


### PR DESCRIPTION
Overall improvment of the Swedish translation, using more standard terms, such as the File-menu being "Arkiv", and reducing the overuse of capital letters. Other less English terms are chosen: existerar > finns, reference > referens, backup > säkerhetskopia, alpha > alfa. As well as removing several hyphens that aren't neccessary.